### PR TITLE
Normalize Project API: remove `name` attribute

### DIFF
--- a/apis/mongodbatlas/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/mongodbatlas/v1alpha1/zz_generated.deepcopy.go
@@ -333,11 +333,6 @@ func (in *ProjectParameters) DeepCopyInto(out *ProjectParameters) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Name != nil {
-		in, out := &in.Name, &out.Name
-		*out = new(string)
-		**out = **in
-	}
 	if in.OrgID != nil {
 		in, out := &in.OrgID, &out.OrgID
 		*out = new(string)

--- a/apis/mongodbatlas/v1alpha1/zz_project_types.go
+++ b/apis/mongodbatlas/v1alpha1/zz_project_types.go
@@ -51,9 +51,6 @@ type ProjectParameters struct {
 	APIKeys []APIKeysParameters `json:"apiKeys,omitempty" tf:"api_keys,omitempty"`
 
 	// +kubebuilder:validation:Required
-	Name *string `json:"name" tf:"name,omitempty"`
-
-	// +kubebuilder:validation:Required
 	OrgID *string `json:"orgId" tf:"org_id,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/common/common.go
+++ b/config/common/common.go
@@ -19,6 +19,7 @@ package common
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	xpref "github.com/crossplane/crossplane-runtime/pkg/reference"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -89,4 +90,12 @@ func Base64EncodeTokens(keyVal ...interface{}) (string, error) {
 		}
 	}
 	return result, nil
+}
+
+// SetIdentifierFunc sets the identifier attribute `name` from a composite
+// external-name where the identifier resides at index 0 of a colon-delimited
+// string.
+func SetIdentifierFunc(base map[string]interface{}, externalName string) {
+	parts := strings.Split(externalName, ":")
+	base["name"] = parts[0]
 }

--- a/config/mongodbatlas/config.go
+++ b/config/mongodbatlas/config.go
@@ -30,7 +30,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("mongodbatlas_cluster", func(r *config.Resource) {
 		r.ExternalName = config.NameAsIdentifier
-		r.ExternalName.SetIdentifierArgumentFn = setIdentifierFunc
+		r.ExternalName.SetIdentifierArgumentFn = common.SetIdentifierFunc
 		r.ExternalName.GetExternalNameFn = getExternalNameFunc
 		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			parts := strings.Split(externalName, ":")
@@ -43,7 +43,7 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("mongodbatlas_advanced_cluster", func(r *config.Resource) {
 		r.ExternalName = config.NameAsIdentifier
-		r.ExternalName.SetIdentifierArgumentFn = setIdentifierFunc
+		r.ExternalName.SetIdentifierArgumentFn = common.SetIdentifierFunc
 		r.ExternalName.GetExternalNameFn = getExternalNameFunc
 		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
 			parts := strings.Split(externalName, ":")
@@ -54,11 +54,6 @@ func Configure(p *config.Provider) {
 		}
 		r.UseAsync = true
 	})
-}
-
-func setIdentifierFunc(base map[string]interface{}, externalName string) {
-	parts := strings.Split(externalName, ":")
-	base["name"] = parts[0]
 }
 
 func getExternalNameFunc(tfstate map[string]interface{}) (string, error) {

--- a/config/project/config.go
+++ b/config/project/config.go
@@ -17,14 +17,37 @@ limitations under the License.
 package project
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
 	"github.com/crossplane/terrajet/pkg/config"
+
+	"github.com/crossplane-contrib/provider-jet-mongodbatlas/config/common"
 )
 
 // Configure configures the root group
 func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("mongodbatlas_project", func(r *config.Resource) {
+		r.ExternalName = config.NameAsIdentifier
+		r.ExternalName.SetIdentifierArgumentFn = common.SetIdentifierFunc
+		r.ExternalName.GetExternalNameFn = getExternalNameFunc
+		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error) {
+			parts := strings.Split(externalName, ":")
+			if len(parts) != 2 {
+				return "", nil
+			}
+			return parts[1], nil
+		}
+	})
+
 	p.AddResourceConfigurator("mongodbatlas_project_ip_access_list", func(r *config.Resource) {
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"ip_address"},
 		}
 	})
+}
+
+func getExternalNameFunc(tfstate map[string]interface{}) (string, error) {
+	return fmt.Sprintf("%s:%s", tfstate["name"], tfstate["id"]), nil
 }

--- a/examples/mongodbatlas/project.yaml
+++ b/examples/mongodbatlas/project.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   forProvider:
     orgId: "<mongodb atlas organization ID>"
-    name: example-project
   providerConfigRef:
     name: default

--- a/internal/controller/mongodbatlas/project/zz_controller.go
+++ b/internal/controller/mongodbatlas/project/zz_controller.go
@@ -47,7 +47,6 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/package/crds/mongodbatlas.jet.crossplane.io_projects.yaml
+++ b/package/crds/mongodbatlas.jet.crossplane.io_projects.yaml
@@ -76,8 +76,6 @@ spec:
                       - roleNames
                       type: object
                     type: array
-                  name:
-                    type: string
                   orgId:
                     type: string
                   projectOwnerId:
@@ -99,7 +97,6 @@ spec:
                   withDefaultAlertsSettings:
                     type: boolean
                 required:
-                - name
                 - orgId
                 type: object
               providerConfigRef:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
This PR proposes a change to remove the `name` attribute from the `Project` managed resource. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested provisioning a new Atlas project and importing an existing Project using the following manifests:

```yaml
apiVersion: mongodbatlas.jet.crossplane.io/v1alpha1
kind: Project
metadata:
  name: example-project
spec:
  forProvider:
    orgId: "<mongodb atlas organization ID>"
  providerConfigRef:
    name: default

---

apiVersion: mongodbatlas.jet.crossplane.io/v1alpha1
kind: Project
metadata:
  name: example-project
  annotations:
    crossplane.io/external-name: <Project name>:<Project ID>
spec:
  forProvider:
    orgId: "<mongodb atlas organization ID>"
  providerConfigRef:
    name: default

```

[contribution process]: https://git.io/fj2m9
