### PR TITLE
chore: remove helderjs from OWNERS.md

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -13,4 +13,3 @@ maintainers, and reviewers.
 
 * Hendrik Leppelsack ([Henni](https://github.com/Henni))
 * J. Fernández ([fernandezcuesta](https://github.com/fernandezcuesta))
-* Helder Santana ([helderjs](https://github.com/helderjs))


### PR DESCRIPTION
### Description of your changes

This PR simply removes helderjs from OWNERS.md as they do not plan on maintaining this provider.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

[contribution process]: https://git.io/fj2m9
