### PR TITLE
fix: CustomRole externalname uses a different ID

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -86,7 +86,7 @@ var externalNameConfigs = map[string]externalNameEntry{
 	"mongodbatlas_cloud_user_team_assignment":                                  templated("{{ .parameters.org_id }}/{{ .parameters.team_id }}/{{ .parameters.username }}", "username"),
 	"mongodbatlas_cluster_outage_simulation":                                   identifierFromProvider(), // doesn't support import
 	"mongodbatlas_cluster":                                                     templated("{{ .parameters.project_id }}-{{ .parameters.name }}", "name"),
-	"mongodbatlas_custom_db_role":                                              templated("{{ .parameters.project_id }}/{{ .parameters.role_name }}", "role_name"),
+	"mongodbatlas_custom_db_role":                                              templated("{{ .parameters.project_id }}-{{ .parameters.role_name }}", "role_name"),
 	"mongodbatlas_custom_dns_configuration_cluster_aws":                        templated("{{ .parameters.project_id }}", "project_id"),
 	"mongodbatlas_database_user":                                               templated("{{ .parameters.project_id }}/{{ .parameters.username }}/{{ .parameters.auth_database_name }}", "username"),
 	"mongodbatlas_encryption_at_rest":                                          templated("{{ .parameters.project_id }}", "project_id"),


### PR DESCRIPTION
### Description of your changes

The external name for `mongodbatlas_custom_db_role` uses `-` instead of `/` and the resource cannot be observed

- Fixes #75

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.
