### PR TITLE
fix: mongodbatlas_privatelink_endpoint creation

### DIFF
--- a/config/cluster/privateendpoint/config.go
+++ b/config/cluster/privateendpoint/config.go
@@ -2,8 +2,6 @@ package privateendpoint
 
 import (
 	"github.com/crossplane/upjet/v2/pkg/config"
-
-	common "github.com/crossplane-contrib/provider-mongodbatlas/config/cluster/common"
 )
 
 const group = "privateendpoint"
@@ -30,11 +28,6 @@ func Configure(p *config.Provider) {
 				TerraformName: "mongodbatlas_project",
 			},
 		}
-		// ID format: {project_id}-{endpoint_id}-{provider_name}-{region}
-		// project_id is hex (no dashes). endpoint_id is the external name (hex).
-		// provider_name and region are suffix segments to skip from the right.
-		r.ExternalName.GetIDFn = common.GetIDFromParamsAndExternalName("-", 1, "project_id", "provider_name", "region")
-		r.ExternalName.GetExternalNameFn = common.ExternalNameFromID("-", 1, 2)
 	})
 
 	p.AddResourceConfigurator("mongodbatlas_privatelink_endpoint_service", func(r *config.Resource) {
@@ -49,9 +42,5 @@ func Configure(p *config.Provider) {
 				TerraformName: "mongodbatlas_privatelink_endpoint",
 			},
 		}
-		// ID format: {project_id}--{private_link_id}--{endpoint_service_id}--{provider_name}
-		// All segments are fixed-format (hex/enum), separator is "--" (unambiguous).
-		r.ExternalName.GetIDFn = common.GetIDFromParamsAndExternalName("--", 2, "project_id", "private_link_id", "provider_name")
-		r.ExternalName.GetExternalNameFn = common.ExternalNameFromID("--", 2, 1)
 	})
 }

--- a/config/namespaced/privateendpoint/config.go
+++ b/config/namespaced/privateendpoint/config.go
@@ -2,8 +2,6 @@ package privateendpoint
 
 import (
 	"github.com/crossplane/upjet/v2/pkg/config"
-
-	common "github.com/crossplane-contrib/provider-mongodbatlas/config/namespaced/common"
 )
 
 const group = "privateendpoint"
@@ -30,11 +28,6 @@ func Configure(p *config.Provider) {
 				TerraformName: "mongodbatlas_project",
 			},
 		}
-		// ID format: {project_id}-{endpoint_id}-{provider_name}-{region}
-		// project_id is hex (no dashes). endpoint_id is the external name (hex).
-		// provider_name and region are suffix segments to skip from the right.
-		r.ExternalName.GetIDFn = common.GetIDFromParamsAndExternalName("-", 1, "project_id", "provider_name", "region")
-		r.ExternalName.GetExternalNameFn = common.ExternalNameFromID("-", 1, 2)
 	})
 
 	p.AddResourceConfigurator("mongodbatlas_privatelink_endpoint_service", func(r *config.Resource) {
@@ -49,9 +42,5 @@ func Configure(p *config.Provider) {
 				TerraformName: "mongodbatlas_privatelink_endpoint",
 			},
 		}
-		// ID format: {project_id}--{private_link_id}--{endpoint_service_id}--{provider_name}
-		// All segments are fixed-format (hex/enum), separator is "--" (unambiguous).
-		r.ExternalName.GetIDFn = common.GetIDFromParamsAndExternalName("--", 2, "project_id", "private_link_id", "provider_name")
-		r.ExternalName.GetExternalNameFn = common.ExternalNameFromID("--", 2, 1)
 	})
 }


### PR DESCRIPTION
## Error
`mongodbatlas_privatelink_endpoint` — `groupId is empty` Bug

## Reported error

When applying any `privateendpoint.mongodbatlas.crossplane.io/v1alpha1 Resource`
(directly or via a Composition that embeds one), the resource gets stuck on the
first reconcile with:

```
observe failed: cannot run refresh: refresh failed: error reading MongoDB Private
Endpoints Connection(): groupId is empty and must be specified:
```

The resource never transitions past Observe, so Create is never attempted from
the Crossplane side. Manually issuing the equivalent Atlas REST call
(`POST /api/atlas/v1.0/groups/{groupId}/privateEndpoint/endpointService`) with
the same credentials returns **201 Created**, confirming the API key,
permissions, project and region are all valid — the failure is entirely
inside the Crossplane provider.

The same symptom applies to `mongodbatlas_privatelink_endpoint_service` (Kind
`Service`).

## Reproduction

```yaml
apiVersion: privateendpoint.mongodbatlas.crossplane.io/v1alpha1
kind: Resource
metadata:
  name: debug-privatelink-aws
spec:
  managementPolicies: ["*"]
  forProvider:
    projectId: xxx   # any valid Atlas project ID
    providerName: AWS
    region: US_EAST_1
  providerConfigRef:
    name: default
```

Apply, then inspect the Terraform workspace inside the provider pod
(`/tmp/<resource-uid>/`):

- `main.tf.json` is **correct** — `project_id`, `provider_name`, `region` are
  all populated.
- `terraform.tfstate` contains:
  ```json
  { "id": "xxx--AWS-US_EAST_1",
    "project_id": "xxx",
    "provider_name": "AWS",
    "region": "US_EAST_1" }
  ```
  The `id` is plaintext and is missing `private_link_id` entirely.


## Root cause

The upstream Terraform provider (`mongodb/mongodbatlas` v2.10.0) encodes the
state `id` for `mongodbatlas_privatelink_endpoint` as a
**base64-encoded URL query string** containing
`project_id`, `private_link_id`, `provider_name`, and `region`.
Its Read function calls `DecodeStateID(d.Id())` on every refresh:

```go
func DecodeStateID(stateID string) map[string]string {
    decode, _ := base64.StdEncoding.DecodeString(stateID)
    decoded, _ := url.ParseQuery(string(decode))
    result := map[string]string{}
    for key := range decoded {
        result[key] = decoded.Get(key)
    }
    return result
}
```

This Crossplane provider's resource configurator overrides the upjet defaults
with a **plaintext, dash-separated ID format**:

```go
// config/cluster/privateendpoint/config.go (and the namespaced mirror)
p.AddResourceConfigurator("mongodbatlas_privatelink_endpoint", func(r *config.Resource) {
    ...
    r.ExternalName.GetIDFn = common.GetIDFromParamsAndExternalName(
        "-", 1, "project_id", "provider_name", "region")
    r.ExternalName.GetExternalNameFn = common.ExternalNameFromID("-", 1, 2)
})
```

`mongodbatlas_privatelink_endpoint` is registered in
`config/external_name.go` with `identifierFromProvider()`, which sets
`config.IdentifierFromProvider` (`DisableNameInitializer: true`). On the first
reconcile the `crossplane.io/external-name` annotation is therefore empty, so
`GetIDFromParamsAndExternalName` builds:

```
{project_id}-{empty}-{provider_name}-{region}
= xxx--AWS-US_EAST_1
```

upjet writes that value into the Terraform state's `id` field before invoking
the upstream provider. On the next refresh the upstream Read function calls
`DecodeStateID`, which fails because the input isn't valid base64 — the
returned map is empty, every field including `project_id` resolves to `""`,
and the SDK call

```go
conn.PrivateEndpoints.Get(ctx, ids["project_id"], ids["provider_name"], ids["private_link_id"])
```

becomes `Get(ctx, "", "", "")`. The Atlas SDK validation fires and returns
`groupId is empty and must be specified`.

The same mismatch exists for `mongodbatlas_privatelink_endpoint_service`
(`--`-separated plaintext on our side, base64 query string upstream).

## Solution

Drop the custom `GetIDFn` / `GetExternalNameFn` overrides for both resources
and rely on `IdentifierFromProvider` defaults
(`GetIDFn = ExternalNameAsID`, `GetExternalNameFn = IDAsExternalName`).

