### PR TITLE
fix(project): encode project_ip_access_list ID via EncodeStateID

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -62,7 +62,7 @@ var externalNameConfigs = map[string]config.ExternalName{
 	"mongodbatlas_privatelink_endpoint":                                        encodedStateID([]string{refs.ProjectID, refs.ProviderName, refs.Region}, "private_link_id"),
 	"mongodbatlas_project_api_key":                                             config.IdentifierFromProvider,
 	"mongodbatlas_project_invitation":                                          config.IdentifierFromProvider,
-	"mongodbatlas_project_ip_access_list":                                      config.IdentifierFromProvider,
+	"mongodbatlas_project_ip_access_list":                                      projectIPAccessListExternalName(),
 	"mongodbatlas_project_service_account_access_list_entry":                   config.IdentifierFromProvider,
 	"mongodbatlas_project_service_account_secret":                              config.IdentifierFromProvider,
 	"mongodbatlas_project_service_account":                                     config.IdentifierFromProvider,
@@ -263,6 +263,52 @@ func hasAllParams(params map[string]any, fields []string) bool {
 		}
 	}
 	return true
+}
+
+// projectIPAccessListExternalName builds the external-name config for
+// mongodbatlas_project_ip_access_list. Like other Atlas resources its TF
+// d.Id() is conversion.EncodeStateID over the keys "entry" and "project_id",
+// so the plain "<project>-<entry>" form fails the read with "the provided
+// resource ID is not correct". It can't use encodedStateID: the "entry" value
+// comes from EITHER the cidr_block or ip_address forProvider field (mutually
+// exclusive), which a static field mapping can't express.
+func projectIPAccessListExternalName() config.ExternalName {
+	const entryKey = "entry"
+	return config.ExternalName{
+		DisableNameInitializer:  true,
+		OmittedFields:           []string{},
+		IdentifierFields:        nil,
+		SetIdentifierArgumentFn: func(_ map[string]any, _ string) {},
+		GetExternalNameFn:       encodedStateGetExternalNameFn(entryKey),
+		GetIDFn: func(_ context.Context, externalName string, parameters, _ map[string]any) (string, error) {
+			project, ok := parameters[refs.ProjectID].(string)
+			if !ok || project == "" {
+				return "", fmt.Errorf("%s is required", refs.ProjectID)
+			}
+			entry := firstNonEmptyParam(parameters, "ip_address", "cidr_block")
+			if entry == "" {
+				// GetExternalNameFn stores the raw entry value in the
+				// crossplane.io/external-name annotation; reuse it when the
+				// forProvider fields aren't available (e.g. on import).
+				entry = externalName
+			}
+			if entry == "" {
+				return "", fmt.Errorf("either ip_address or cidr_block is required")
+			}
+			return encodeAtlasStateID(map[string]string{entryKey: entry, refs.ProjectID: project}), nil
+		},
+	}
+}
+
+// firstNonEmptyParam returns the value of the first key present and non-empty
+// in params, or "" if none match.
+func firstNonEmptyParam(params map[string]any, keys ...string) string {
+	for _, k := range keys {
+		if s, ok := params[k].(string); ok && s != "" {
+			return s
+		}
+	}
+	return ""
 }
 
 // ExternalNameConfigurations applies the external name config for each resource.

--- a/config/external_name_test.go
+++ b/config/external_name_test.go
@@ -280,3 +280,60 @@ func TestHasAllParams(t *testing.T) {
 		})
 	}
 }
+
+func TestProjectIPAccessListGetIDFn(t *testing.T) {
+	e := projectIPAccessListExternalName()
+	tests := []struct {
+		name      string
+		params    map[string]any
+		wantEntry string
+	}{
+		{
+			name:      "cidr_block",
+			params:    map[string]any{refs.ProjectID: testProjectID, "cidr_block": "10.0.0.0/24"},
+			wantEntry: "10.0.0.0/24",
+		},
+		{
+			name:      "ip_address",
+			params:    map[string]any{refs.ProjectID: testProjectID, "ip_address": "1.2.3.4"},
+			wantEntry: "1.2.3.4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := e.GetIDFn(context.Background(), "", tt.params, nil)
+			require.NoError(t, err)
+
+			// Must round-trip through DecodeStateID to exactly two keys, or the
+			// TF provider read errors "the provided resource ID is not correct".
+			decoded := decodeAtlasStateID(id)
+			assert.Len(t, decoded, 2)
+			assert.Equal(t, testProjectID, decoded[refs.ProjectID])
+			assert.Equal(t, tt.wantEntry, decoded["entry"])
+		})
+	}
+}
+
+func TestProjectIPAccessListGetIDFn_Errors(t *testing.T) {
+	e := projectIPAccessListExternalName()
+
+	t.Run("missing entry (no ip_address/cidr_block)", func(t *testing.T) {
+		_, err := e.GetIDFn(context.Background(), "", map[string]any{refs.ProjectID: testProjectID}, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing project_id", func(t *testing.T) {
+		_, err := e.GetIDFn(context.Background(), "", map[string]any{"cidr_block": "10.0.0.0/24"}, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("entry recovered from external-name when params absent", func(t *testing.T) {
+		// GetExternalNameFn stores the raw entry value; GetIDFn reuses it when
+		// neither ip_address nor cidr_block is in forProvider.
+		id, err := e.GetIDFn(context.Background(), "1.2.3.4", map[string]any{refs.ProjectID: testProjectID}, nil)
+		require.NoError(t, err)
+		decoded := decodeAtlasStateID(id)
+		assert.Equal(t, "1.2.3.4", decoded["entry"])
+		assert.Equal(t, testProjectID, decoded[refs.ProjectID])
+	})
+}

--- a/config/resources/project.go
+++ b/config/resources/project.go
@@ -49,20 +49,9 @@ func ConfigureProject(p *config.Provider) {
 				TerraformName: refs.TFProject,
 			},
 		}
-		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, parameters map[string]any, setup map[string]any) (string, error) {
-			project, ok := parameters[refs.ProjectID]
-			if !ok {
-				return "", errors.New("project_id missing from parameters")
-			}
-			ip, ok := parameters["ip_address"]
-			if !ok {
-				ip, ok = parameters["cidr_block"]
-				if !ok {
-					return "", errors.New("either ip_address or cidr_block parameters must be set")
-				}
-			}
-			return fmt.Sprintf("%s-%s", project, ip), nil
-		}
+		// External-name / ID handling lives in config.projectIPAccessListExternalName
+		// (EncodeStateID form). The default ExternalNameConfigurations option applies
+		// it; no GetIDFn override here.
 	})
 
 	p.AddResourceConfigurator("mongodbatlas_third_party_integration", func(r *config.Resource) {


### PR DESCRIPTION
### Description of your changes

`mongodbatlas_project_ip_access_list` configured its `GetIDFn` (in `config/resources/project.go`) to build a **plain** `"<project_id>-<entry>"` terraform ID:

```go
return fmt.Sprintf("%s-%s", project, ip), nil
```

But `terraform-provider-mongodbatlas` (v2.x, plugin-framework) reads this resource with `conversion.DecodeStateID` and rejects any ID that doesn't decode to exactly `{project_id, entry}`:

```go
decodedIDMap := conversion.DecodeStateID(...)
if len(decodedIDMap) != 2 {
    resp.Diagnostics.AddError("error during the reading operation", "the provided resource ID is not correct")
}
```

So every observe fails:

```
observe failed: cannot run refresh: refresh failed: error during the reading
operation: the provided resource ID is not correct
```

And because `GetIDFn` returns a non-empty ID from parameters, upjet runs the refresh on the **first** reconcile and never reaches Create — the access-list entry is never added and the MR is stuck `Synced=False` with an empty `crossplane.io/external-name`.

This is the same `EncodeStateID` scheme the repo already handles for other Atlas resources via `encodedStateID`. This PR:

- Adds `config.projectIPAccessListExternalName()`, which builds the ID with the existing `encodeAtlasStateID` helper (keys `entry` + `project_id`). The `entry` value comes from **either** `cidr_block` or `ip_address` (mutually exclusive), which the static `encodedStateID`/`encodedStateIDMapped` helpers can't express — hence a small dedicated config rather than a map entry.
- Points `"mongodbatlas_project_ip_access_list"` at it in `externalNameConfigs` (was `config.IdentifierFromProvider`).
- Removes the stale plain-format `GetIDFn` override in `config/resources/project.go` so the default external-name config applies (`References`/`LateInitializer` kept).
- Adds unit tests covering both `cidr_block` and `ip_address`, the two-key round-trip through `DecodeStateID`, the error paths, and entry recovery from `external-name`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

> Ran `go build ./config/...` and `go test ./config/...` locally (all pass). Full `make reviewable` left to CI.

### How has this code been tested

- Unit tests in `config/external_name_test.go` (`TestProjectIPAccessListGetIDFn`, `TestProjectIPAccessListGetIDFn_Errors`) — assert the encoded ID decodes back to exactly `{project_id, entry}` for both `cidr_block` and `ip_address`.
- **Verified live** against a real MongoDB Atlas project with provider built from this branch (bundling terraform-provider-mongodbatlas `v2.12.0`): the `IPAccessList` MR reconciles to `Synced=True`/`Ready=True` and the entry appears in the project's access list. Before the fix the same MR failed with `the provided resource ID is not correct`.

[contribution process]: https://git.io/fj2m9
