### PR TITLE
feat: use a shared terraform provider scheduler

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -39,15 +39,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	authv1 "k8s.io/api/authorization/v1"
-	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -152,37 +148,11 @@ func main() {
 		cli.CertsDir = certsDirFromEnv(cli.CertsDir)
 	}
 
-	// The safe-start gate only reads group/names/versions and the Established
-	// condition from CRDs, never the schema, so cached CRDs are stripped
-	// before storage to keep the provider's memory footprint bounded on
-	// clusters with many (large-schema) CRDs.
-	crdCacheByObject := cache.ByObject{Transform: stripCachedCRD}
-
-	// The CRD ByObject cache entry below requires the apiextensions types to
-	// be registered before the manager is constructed, so the scheme is built
-	// up front instead of relying on post-construction AddToScheme calls.
-	sch := runtime.NewScheme()
-	ctx.FatalIfErrorf(clientgoscheme.AddToScheme(sch), "Cannot add client-go APIs to scheme")
-	ctx.FatalIfErrorf(apiextensionsv1.AddToScheme(sch), "Cannot add api-extensions APIs to scheme")
-
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:           sch,
 		LeaderElection:   cli.LeaderElection,
 		LeaderElectionID: "crossplane-leader-election-upjet-provider-mongodbatlas",
 		Cache: cache.Options{
 			SyncPeriod: &cli.SyncPeriod,
-			ByObject: map[client.Object]cache.ByObject{
-				&apiextensionsv1.CustomResourceDefinition{}: crdCacheByObject,
-			},
-		},
-		Client: client.Options{
-			Cache: &client.CacheOptions{
-				// Secrets are only ever point-read (credential resolution,
-				// connection-secret publishing, password initializer), never
-				// watched. Keeping them out of the cache avoids holding every
-				// Secret in the cluster in memory.
-				DisableFor: []client.Object{&corev1.Secret{}},
-			},
 		},
 		PprofBindAddress: cli.PprofBindAddress,
 		Metrics: metricsserver.Options{
@@ -201,6 +171,7 @@ func main() {
 	ctx.FatalIfErrorf(err, "Cannot create controller manager")
 	ctx.FatalIfErrorf(apisCluster.AddToScheme(mgr.GetScheme()), "Cannot add cluster-scoped MongoDBAtlas APIs to scheme")
 	ctx.FatalIfErrorf(apisNamespaced.AddToScheme(mgr.GetScheme()), "Cannot add namespaced MongoDBAtlas APIs to scheme")
+	ctx.FatalIfErrorf(apiextensionsv1.AddToScheme(mgr.GetScheme()), "Cannot add api-extensions APIs to scheme")
 	ctx.FatalIfErrorf(authv1.AddToScheme(mgr.GetScheme()), "Cannot add k8s authorization APIs to scheme")
 
 	// A single scheduler instance is shared across both provider scopes so
@@ -348,25 +319,6 @@ func certsDirFromEnv(fallback certsDir) certsDir {
 		return certsDir(xpCertsDir)
 	}
 	return fallback
-}
-
-// stripCachedCRD drops the parts of a CRD that the provider never reads
-// before it enters the manager cache. The only cached-CRD consumer is the
-// safe-start gate (customresourcesgate), which reads group/names/versions and
-// the Established condition — never the OpenAPI schema. On clusters with many
-// CRDs the schemas dominate the provider's memory footprint. Anything reading
-// CRDs through mgr.GetClient() will see these stripped objects.
-func stripCachedCRD(obj any) (any, error) {
-	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
-	if !ok {
-		return obj, nil
-	}
-	for i := range crd.Spec.Versions {
-		crd.Spec.Versions[i].Schema = nil
-	}
-	crd.ManagedFields = nil
-	delete(crd.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
-	return crd, nil
 }
 
 func canWatchCRD(ctx context.Context, mgr manager.Manager) (bool, error) {

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -39,11 +39,15 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	authv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -65,6 +69,16 @@ const (
 	tlsServerCertDirEnvVar  = "TLS_SERVER_CERTS_DIR"
 	certsDirEnvVar          = "CERTS_DIR"
 	tlsServerCertDir        = "/tls/server"
+
+	// nativeProviderPathEnvVar points to the Terraform native provider plugin
+	// binary shipped in the provider image. Used by the shared provider
+	// scheduler (--terraform-shared-scheduler).
+	nativeProviderPathEnvVar = "TERRAFORM_NATIVE_PROVIDER_PATH"
+
+	// terraformProtocolVersion is the Terraform plugin protocol version spoken
+	// by the MongoDB Atlas native provider. It serves protocol 6 via tf6server,
+	// so the shared provider runner must reattach using the same version.
+	terraformProtocolVersion = 6
 )
 
 type certsDir string
@@ -83,7 +97,12 @@ var cli struct {
 	PollInterval            time.Duration `help:"How often individual resources will be checked for drift from the desired state" default:"1m"`
 	PollStateMetricInterval time.Duration `help:"State metric recording interval" default:"5s"`
 
-	MaxReconcileRate         int           `help:"The global maximum rate per second at which resources may checked for drift from the desired state." default:"10"`
+	MaxReconcileRate int `help:"The global maximum rate per second at which resources may checked for drift from the desired state." default:"10"`
+
+	PprofBindAddress         string `help:"The address the pprof profiling server listens on (e.g. :8083). Empty disables profiling." default:"" env:"PPROF_BIND_ADDRESS"`
+	TerraformSharedScheduler bool   `help:"Share a single Terraform native provider plugin process across all workspaces instead of spawning one per workspace. Requires the native provider binary in the image (TERRAFORM_NATIVE_PROVIDER_PATH)." default:"false" env:"TERRAFORM_SHARED_SCHEDULER"`
+	ProviderTTL              int    `help:"Number of invocations after which a shared Terraform native provider process is recycled (only used with --terraform-shared-scheduler)." default:"100" env:"PROVIDER_TTL"`
+
 	EnableManagementPolicies bool          `help:"Enable support for Management Policies." default:"true" env:"ENABLE_MANAGEMENT_POLICIES"`
 	EnableChangeLogs         bool          `help:"Enable support for capturing change logs during reconciliation." default:"false" env:"ENABLE_CHANGE_LOGS"`
 	ChangelogsSocketPath     string        `help:"Path for changelogs socket (if enabled)" default:"/var/run/changelogs/changelogs.sock" env:"CHANGELOGS_SOCKET_PATH"`
@@ -129,34 +148,43 @@ func main() {
 	cfg, err := ctrl.GetConfig()
 	ctx.FatalIfErrorf(err, "Cannot get API server rest config")
 
-	// Get the TLS certs directory from the environment variables set by
-	// Crossplane if they're available.
-	// In older XP versions we used WEBHOOK_TLS_CERT_DIR, in newer versions
-	// we use TLS_SERVER_CERTS_DIR. If an explicit certs dir is not supplied
-	// via the command-line options, then these environment variables are used
-	// instead.
 	if !certsDirSet {
-		// backwards-compatibility concerns
-		xpCertsDir := os.Getenv(certsDirEnvVar)
-		if xpCertsDir == "" {
-			xpCertsDir = os.Getenv(tlsServerCertDirEnvVar)
-		}
-		if xpCertsDir == "" {
-			xpCertsDir = os.Getenv(webhookTLSCertDirEnvVar)
-		}
-		// we probably don't need this condition but just to be on the
-		// safe side, if we are missing any kong machinery details...
-		if xpCertsDir != "" {
-			cli.CertsDir = certsDir(xpCertsDir)
-		}
+		cli.CertsDir = certsDirFromEnv(cli.CertsDir)
 	}
 
+	// The safe-start gate only reads group/names/versions and the Established
+	// condition from CRDs, never the schema, so cached CRDs are stripped
+	// before storage to keep the provider's memory footprint bounded on
+	// clusters with many (large-schema) CRDs.
+	crdCacheByObject := cache.ByObject{Transform: stripCachedCRD}
+
+	// The CRD ByObject cache entry below requires the apiextensions types to
+	// be registered before the manager is constructed, so the scheme is built
+	// up front instead of relying on post-construction AddToScheme calls.
+	sch := runtime.NewScheme()
+	ctx.FatalIfErrorf(clientgoscheme.AddToScheme(sch), "Cannot add client-go APIs to scheme")
+	ctx.FatalIfErrorf(apiextensionsv1.AddToScheme(sch), "Cannot add api-extensions APIs to scheme")
+
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:           sch,
 		LeaderElection:   cli.LeaderElection,
 		LeaderElectionID: "crossplane-leader-election-upjet-provider-mongodbatlas",
 		Cache: cache.Options{
 			SyncPeriod: &cli.SyncPeriod,
+			ByObject: map[client.Object]cache.ByObject{
+				&apiextensionsv1.CustomResourceDefinition{}: crdCacheByObject,
+			},
 		},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				// Secrets are only ever point-read (credential resolution,
+				// connection-secret publishing, password initializer), never
+				// watched. Keeping them out of the cache avoids holding every
+				// Secret in the cluster in memory.
+				DisableFor: []client.Object{&corev1.Secret{}},
+			},
+		},
+		PprofBindAddress: cli.PprofBindAddress,
 		Metrics: metricsserver.Options{
 			BindAddress: cli.MetricsBindAddress,
 		},
@@ -173,8 +201,14 @@ func main() {
 	ctx.FatalIfErrorf(err, "Cannot create controller manager")
 	ctx.FatalIfErrorf(apisCluster.AddToScheme(mgr.GetScheme()), "Cannot add cluster-scoped MongoDBAtlas APIs to scheme")
 	ctx.FatalIfErrorf(apisNamespaced.AddToScheme(mgr.GetScheme()), "Cannot add namespaced MongoDBAtlas APIs to scheme")
-	ctx.FatalIfErrorf(apiextensionsv1.AddToScheme(mgr.GetScheme()), "Cannot add api-extensions APIs to scheme")
 	ctx.FatalIfErrorf(authv1.AddToScheme(mgr.GetScheme()), "Cannot add k8s authorization APIs to scheme")
+
+	// A single scheduler instance is shared across both provider scopes so
+	// that all workspaces reattach to the same native provider process(es).
+	scheduler := newProviderScheduler(cli.TerraformSharedScheduler, log, cli.ProviderTTL, cli.ProviderSource)
+	if scheduler != nil {
+		log.Info("Terraform shared provider scheduler enabled", "ttl", cli.ProviderTTL)
+	}
 
 	metricRecorder := managed.NewMRMetricRecorder()
 	stateMetrics := statemetrics.NewMRStateMetrics()
@@ -196,7 +230,7 @@ func main() {
 			},
 		},
 		Provider:       config.GetidentifierFromProvider(),
-		SetupFn:        clients.TerraformSetupBuilder(cli.TerraformVersion, cli.ProviderSource, cli.ProviderVersion),
+		SetupFn:        clients.TerraformSetupBuilder(cli.TerraformVersion, cli.ProviderSource, cli.ProviderVersion, scheduler),
 		WorkspaceStore: terraform.NewWorkspaceStore(log),
 		PollJitter:     pollJitter,
 		StartWebhooks:  cli.CertsDir != "",
@@ -216,7 +250,7 @@ func main() {
 			},
 		},
 		Provider:       config.GetProviderNamespaced(),
-		SetupFn:        clients.TerraformSetupBuilder(cli.TerraformVersion, cli.ProviderSource, cli.ProviderVersion),
+		SetupFn:        clients.TerraformSetupBuilder(cli.TerraformVersion, cli.ProviderSource, cli.ProviderVersion, scheduler),
 		WorkspaceStore: terraform.NewWorkspaceStore(log),
 		PollJitter:     pollJitter,
 		StartWebhooks:  cli.CertsDir != "",
@@ -270,6 +304,69 @@ func main() {
 	}
 
 	ctx.FatalIfErrorf(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
+}
+
+// newProviderScheduler returns a shared Terraform provider scheduler when
+// enabled and the native provider binary path is available, otherwise nil
+// (in which case the Terraform CLI manages one plugin process per workspace).
+func newProviderScheduler(enabled bool, log logging.Logger, ttl int, providerSource string) terraform.ProviderScheduler {
+	if !enabled {
+		return nil
+	}
+	nativePath := os.Getenv(nativeProviderPathEnvVar)
+	if nativePath == "" {
+		log.Info("Shared provider scheduler requested but " + nativeProviderPathEnvVar + " is empty; falling back to per-workspace provider processes")
+		return nil
+	}
+	return terraform.NewSharedProviderScheduler(log, ttl,
+		terraform.WithSharedProviderOptions(
+			terraform.WithNativeProviderPath(nativePath),
+			terraform.WithNativeProviderName("registry.terraform.io/"+providerSource),
+			terraform.WithProtocolVersion(terraformProtocolVersion),
+		),
+	)
+}
+
+// certsDirFromEnv returns the TLS certs directory from the environment
+// variables set by Crossplane if they're available.
+// In older XP versions we used WEBHOOK_TLS_CERT_DIR, in newer versions
+// we use TLS_SERVER_CERTS_DIR. If an explicit certs dir is not supplied
+// via the command-line options, then these environment variables are used
+// instead.
+func certsDirFromEnv(fallback certsDir) certsDir {
+	// backwards-compatibility concerns
+	xpCertsDir := os.Getenv(certsDirEnvVar)
+	if xpCertsDir == "" {
+		xpCertsDir = os.Getenv(tlsServerCertDirEnvVar)
+	}
+	if xpCertsDir == "" {
+		xpCertsDir = os.Getenv(webhookTLSCertDirEnvVar)
+	}
+	// we probably don't need this condition but just to be on the
+	// safe side, if we are missing any kong machinery details...
+	if xpCertsDir != "" {
+		return certsDir(xpCertsDir)
+	}
+	return fallback
+}
+
+// stripCachedCRD drops the parts of a CRD that the provider never reads
+// before it enters the manager cache. The only cached-CRD consumer is the
+// safe-start gate (customresourcesgate), which reads group/names/versions and
+// the Established condition — never the OpenAPI schema. On clusters with many
+// CRDs the schemas dominate the provider's memory footprint. Anything reading
+// CRDs through mgr.GetClient() will see these stripped objects.
+func stripCachedCRD(obj any) (any, error) {
+	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		return obj, nil
+	}
+	for i := range crd.Spec.Versions {
+		crd.Spec.Versions[i].Schema = nil
+	}
+	crd.ManagedFields = nil
+	delete(crd.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
+	return crd, nil
 }
 
 func canWatchCRD(ctx context.Context, mgr manager.Manager) (bool, error) {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/crossplane/crossplane-runtime/v2 v2.2.0
 	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
-	github.com/crossplane/upjet/v2 v2.3.0
+	github.com/crossplane/upjet/v2 v2.3.1-0.20260713112758-3dc7c7822463
 	github.com/go-logr/logr v1.4.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/pkg/errors v0.9.1
@@ -163,5 +163,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-replace github.com/crossplane/upjet/v2 => github.com/fernandezcuesta/upjet/v2 v2.0.0-20260623174553-8055fad32831

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/crossplane/crossplane-runtime/v2 v2.2.0 h1:jLoQm9D5buk9lBqwRtQ40ueaFo
 github.com/crossplane/crossplane-runtime/v2 v2.2.0/go.mod h1:8I+x4w5bG4x8aO8ifF/QC8GZoNCN6v21NHzgoYPNYAQ=
 github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339 h1:MPbMxSlY+82UsjrLUAGyXlh/iX1tL5WNj8W9SOaq/nk=
 github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339/go.mod h1:8etxwmP4cZwJDwen4+PQlnc1tggltAhEfyyigmdHulQ=
+github.com/crossplane/upjet/v2 v2.3.1-0.20260713112758-3dc7c7822463 h1:tdLpEAF7gpA4ng7z56qjru89oXq8Wj8iPvsXSBfJwLg=
+github.com/crossplane/upjet/v2 v2.3.1-0.20260713112758-3dc7c7822463/go.mod h1:5eAaUqFKfA0LAlkywhQVj3jBAvepqb4pJAb9EsdWsuM=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=
 github.com/dave/jennifer v1.7.1/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -68,8 +70,6 @@ github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fernandezcuesta/upjet/v2 v2.0.0-20260623174553-8055fad32831 h1:yboqKN2bzYbcaZvzLJ29Wiywzco+JgjYn/7K1TZEZnw=
-github.com/fernandezcuesta/upjet/v2 v2.0.0-20260623174553-8055fad32831/go.mod h1:5eAaUqFKfA0LAlkywhQVj3jBAvepqb4pJAb9EsdWsuM=
 github.com/fsnotify/fsnotify v1.10.0 h1:Xx/5Ydg9CeBDX/wi4VJqStNtohYjitZhhlHt4h3St1M=
 github.com/fsnotify/fsnotify v1.10.0/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=

--- a/internal/clients/mongodbatlas.go
+++ b/internal/clients/mongodbatlas.go
@@ -46,8 +46,10 @@ const (
 )
 
 // TerraformSetupBuilder builds Terraform a terraform.SetupFn function which
-// returns Terraform provider setup configuration
-func TerraformSetupBuilder(version, providerSource, providerVersion string) terraform.SetupFn {
+// returns Terraform provider setup configuration. When scheduler is non-nil,
+// it is attached to every Setup so that the Terraform native provider plugin
+// process is shared across workspaces instead of spawned per workspace.
+func TerraformSetupBuilder(version, providerSource, providerVersion string, scheduler terraform.ProviderScheduler) terraform.SetupFn {
 	return func(ctx context.Context, client client.Client, mg resource.Managed) (terraform.Setup, error) {
 		ps := terraform.Setup{
 			Version: version,
@@ -55,6 +57,7 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 				Source:  providerSource,
 				Version: providerVersion,
 			},
+			Scheduler: scheduler,
 		}
 
 		pcSpec, err := resolveProviderConfig(ctx, client, mg)


### PR DESCRIPTION
Reduce memory footprint via shared Terraform provider scheduler and CRD cache stripping.

- Shared Terraform provider scheduler (opt-in via --terraform-shared-scheduler / `TERRAFORM_SHARED_SCHEDULER`): runs a single long-lived native terraform-provider-mongodbatlas process shared across all workspaces via TF_REATTACH_PROVIDERS, instead of forking one plugin process per reconcile. `--provider-ttl` (default 100) controls how many invocations before the shared process is recycled. Uses the native provider binary and env already staged in the image.

- `--pprof-bind-address` flag for heap profiling.
- Dropped the custom upjet fork; now on upstream crossplane/upjet (the `GetImportIDFn` change we forked for merged upstream).

Notes:
- The shared scheduler is opt-in and defaults off; the reattach handshake (protocol 6) should be validated on an actively-reconciling cluster before enabling in production.
