### PR TITLE
fix: duplicated getidfn call

### DIFF
--- a/config/resources/mongodbatlas.go
+++ b/config/resources/mongodbatlas.go
@@ -337,7 +337,6 @@ func ConfigureMongoDBAtlas(p *config.Provider) {
 		r.ShortGroup = ""
 		r.Kind = "AccessListAPIKey"
 		r.ExternalName = accessListImportJoinedID([]string{refs.OrgID, "api_key_id"})
-		r.ExternalName.GetIDFn = refs.AccessListGetIDFn(refs.OrgID, "api_key_id")
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"ip_address"},
 		}

--- a/config/resources/project.go
+++ b/config/resources/project.go
@@ -40,7 +40,6 @@ func ConfigureProject(p *config.Provider) {
 
 	p.AddResourceConfigurator("mongodbatlas_project_ip_access_list", func(r *config.Resource) {
 		r.ExternalName = accessListImportJoinedID([]string{refs.ProjectID})
-		r.ExternalName.GetIDFn = refs.AccessListGetIDFn(refs.ProjectID)
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"ip_address"},
 		}


### PR DESCRIPTION
It was detected that for 2 resources we're setting GetIDFn twice: once in the convenience helper and again right after calling it, the latter one being incorrect and causing issues.

Fixes #126 